### PR TITLE
Add IC and OOC commands and support

### DIFF
--- a/src/client/rp_proxy_events.ts
+++ b/src/client/rp_proxy_events.ts
@@ -1,0 +1,15 @@
+import { Client, Events } from 'discord.js';
+
+import { handleRoleplayProxyMessage } from '../services/rp_message_proxy.service';
+
+export function initializeRoleplayProxy(client: Client): void {
+  client.on(Events.MessageCreate, (message) => {
+    void (async () => {
+      try {
+        await handleRoleplayProxyMessage(message);
+      } catch (err) {
+        console.error('[rp_proxy_events] Failed to process RP proxy message:', err);
+      }
+    })();
+  });
+}

--- a/src/commands/create-character.ts
+++ b/src/commands/create-character.ts
@@ -84,6 +84,8 @@ module.exports = {
       { name: 'core:name', label: '[CORE] Name' },
       { name: 'core:bio', label: '[CORE] Bio' },
       { name: 'core:avatar_url', label: '[CORE] Avatar URL' },
+      { name: 'core:rp_display_name', label: '[CORE] RP Display Name' },
+      { name: 'core:rp_display_avatar_url', label: '[CORE] RP Display Avatar URL' },
     ];
 
     const gameFields: LabeledField[] = statTemplates.map((f) => ({

--- a/src/commands/ic.ts
+++ b/src/commands/ic.ts
@@ -1,0 +1,39 @@
+import {
+  CacheType,
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+} from 'discord.js';
+
+import { setChannelInCharacterMode } from '../services/rp_channel_mode.service';
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ic')
+    .setDescription('Set this channel to in-character roleplay proxy mode.')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+
+  async execute(interaction: ChatInputCommandInteraction<CacheType>) {
+    const { channelId, guildId, user } = interaction;
+
+    if (!guildId) {
+      return interaction.reply({
+        content: '⚠️ This command must be used in a server.',
+        ephemeral: true,
+      });
+    }
+
+    await setChannelInCharacterMode({
+      guildId,
+      channelId,
+      isIc: true,
+      updatedBy: user.id,
+    });
+
+    return interaction.reply({
+      content:
+        '✅ This channel is now in-character. Player messages will proxy through their active character.',
+      ephemeral: true,
+    });
+  },
+};

--- a/src/commands/ooc.ts
+++ b/src/commands/ooc.ts
@@ -1,0 +1,38 @@
+import {
+  CacheType,
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+} from 'discord.js';
+
+import { setChannelInCharacterMode } from '../services/rp_channel_mode.service';
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ooc')
+    .setDescription('Set this channel to out-of-character mode.')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+
+  async execute(interaction: ChatInputCommandInteraction<CacheType>) {
+    const { channelId, guildId, user } = interaction;
+
+    if (!guildId) {
+      return interaction.reply({
+        content: '⚠️ This command must be used in a server.',
+        ephemeral: true,
+      });
+    }
+
+    await setChannelInCharacterMode({
+      guildId,
+      channelId,
+      isIc: false,
+      updatedBy: user.id,
+    });
+
+    return interaction.reply({
+      content: '✅ This channel is now out-of-character. Messages will no longer be proxied.',
+      ephemeral: true,
+    });
+  },
+};

--- a/src/components/edit_character_stats_button.ts
+++ b/src/components/edit_character_stats_button.ts
@@ -42,6 +42,18 @@ async function handle(interaction: ButtonInteraction): Promise<void> {
   const coreFields = [
     { value: 'core:name', label: 'Name', type: 'short', current: character.name },
     { value: 'core:avatar_url', label: 'Avatar URL', type: 'short', current: character.avatar_url },
+    {
+      value: 'core:rp_display_name',
+      label: 'RP Display Name',
+      type: 'short',
+      current: character.rp_display_name,
+    },
+    {
+      value: 'core:rp_display_avatar_url',
+      label: 'RP Display Avatar URL',
+      type: 'short',
+      current: character.rp_display_avatar_url,
+    },
     { value: 'core:bio', label: 'Bio', type: 'paragraph', current: character.bio },
     { value: 'core:visibility', label: 'Visibility', type: 'short', current: character.visibility },
   ];

--- a/src/dao/character.dao.ts
+++ b/src/dao/character.dao.ts
@@ -5,6 +5,8 @@ import { query } from '../db/client';
 interface CharacterMeta {
   name: string;
   avatar_url?: string | null;
+  rp_display_name?: string | null;
+  rp_display_avatar_url?: string | null;
   bio?: string | null;
   visibility?: 'public' | 'private';
 }
@@ -20,15 +22,35 @@ export class CharacterDAO {
     game_id,
     name,
     avatar_url = null,
+    rp_display_name = null,
+    rp_display_avatar_url = null,
     bio = null,
     visibility = 'private',
   }: CreateCharacterParams): Promise<Record<string, any>> {
     const sql = `
-      INSERT INTO character (user_id, game_id, name, avatar_url, bio, visibility)
-      VALUES ($1, $2, $3, $4, $5, $6)
+      INSERT INTO character (
+        user_id,
+        game_id,
+        name,
+        avatar_url,
+        rp_display_name,
+        rp_display_avatar_url,
+        bio,
+        visibility
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
       RETURNING *
     `;
-    const params = [user_id.trim(), game_id, name, avatar_url, bio, visibility];
+    const params = [
+      user_id.trim(),
+      game_id,
+      name,
+      avatar_url,
+      rp_display_name,
+      rp_display_avatar_url,
+      bio,
+      visibility,
+    ];
     const result = await query(sql, params);
     return result.rows[0];
   }
@@ -55,18 +77,35 @@ export class CharacterDAO {
 
   async updateMeta(
     characterId: string,
-    { name, avatar_url = null, bio = null, visibility = 'private' }: CharacterMeta,
+    {
+      name,
+      avatar_url = null,
+      rp_display_name = null,
+      rp_display_avatar_url = null,
+      bio = null,
+      visibility = 'private',
+    }: CharacterMeta,
   ): Promise<Record<string, any>> {
     const sql = `
       UPDATE character
       SET name = $1,
           avatar_url = $2,
-          bio = $3,
-          visibility = $4
-      WHERE id = $5
+          rp_display_name = $3,
+          rp_display_avatar_url = $4,
+          bio = $5,
+          visibility = $6
+      WHERE id = $7
       RETURNING *
     `;
-    const result = await query(sql, [name, avatar_url, bio, visibility, characterId]);
+    const result = await query(sql, [
+      name,
+      avatar_url,
+      rp_display_name,
+      rp_display_avatar_url,
+      bio,
+      visibility,
+      characterId,
+    ]);
     return result.rows[0];
   }
 

--- a/src/dao/rp_channel_mode.dao.ts
+++ b/src/dao/rp_channel_mode.dao.ts
@@ -1,0 +1,46 @@
+import { query } from '../db/client';
+
+export interface RpChannelMode {
+  guild_id: string;
+  channel_id: string;
+  is_ic: boolean;
+  updated_by: string;
+  updated_at: string;
+}
+
+export class RpChannelModeDAO {
+  async setMode({
+    guildId,
+    channelId,
+    isIc,
+    updatedBy,
+  }: {
+    guildId: string;
+    channelId: string;
+    isIc: boolean;
+    updatedBy: string;
+  }): Promise<RpChannelMode> {
+    const sql = `
+      INSERT INTO rp_channel_mode (guild_id, channel_id, is_ic, updated_by)
+      VALUES ($1, $2, $3, $4)
+      ON CONFLICT (guild_id, channel_id)
+      DO UPDATE SET
+        is_ic = EXCLUDED.is_ic,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = CURRENT_TIMESTAMP
+      RETURNING *
+    `;
+
+    const result = await query<RpChannelMode>(sql, [guildId, channelId, isIc, updatedBy]);
+    return result.rows[0];
+  }
+
+  async isInCharacter(guildId: string, channelId: string): Promise<boolean> {
+    const result = await query<{ is_ic: boolean }>(
+      `SELECT is_ic FROM rp_channel_mode WHERE guild_id = $1 AND channel_id = $2`,
+      [guildId, channelId],
+    );
+
+    return result.rows[0]?.is_ic ?? false;
+  }
+}

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -170,6 +170,7 @@ export async function resetDb(): Promise<void> {
     'character',
     'stat_template',
     'game',
+    'rp_channel_mode',
     'thread_bumps',
     'entitlements_cache',
     'gifted_guilds',

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -38,6 +38,7 @@ export async function initializeDB(): Promise<void> {
       'character_inventory',
       'character_inventory_field',
       'thread_bumps', // <— NEW
+      'rp_channel_mode',
     ];
 
     // 🔍 Check which tables exist

--- a/src/db/tables/002_roleplay_proxy.sql
+++ b/src/db/tables/002_roleplay_proxy.sql
@@ -1,0 +1,15 @@
+ALTER TABLE character
+  ADD COLUMN IF NOT EXISTS rp_display_name TEXT,
+  ADD COLUMN IF NOT EXISTS rp_display_avatar_url TEXT;
+
+CREATE TABLE IF NOT EXISTS rp_channel_mode (
+  guild_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  is_ic BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_by TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (guild_id, channel_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rp_channel_mode_guild_id
+  ON rp_channel_mode(guild_id);

--- a/src/db/tables/tables.sql
+++ b/src/db/tables/tables.sql
@@ -37,11 +37,23 @@ CREATE TABLE character (
   user_id TEXT NOT NULL, -- Discord user ID
   name TEXT NOT NULL,
   avatar_url TEXT,
+  rp_display_name TEXT,
+  rp_display_avatar_url TEXT,
   bio TEXT,
   visibility TEXT DEFAULT 'private' CHECK (visibility IN ('private', 'public', 'link-only')),
   deleted_at TIMESTAMP,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   last_updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- === ROLEPLAY PROXY CHANNEL MODE ===
+CREATE TABLE rp_channel_mode (
+  guild_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  is_ic BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_by TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (guild_id, channel_id)
 );
 
 -- === PLAYER ACCOUNTS (GLOBAL IDENTITY) ===
@@ -157,6 +169,7 @@ CREATE INDEX idx_game_guild_id ON game(guild_id);
 -- Character lookups
 CREATE INDEX idx_character_user_id ON character(user_id);
 CREATE INDEX idx_character_game_id ON character(game_id);
+CREATE INDEX idx_rp_channel_mode_guild_id ON rp_channel_mode(guild_id);
 
 -- Stat lookups
 CREATE INDEX idx_stat_character_id ON character_stat_field(character_id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,17 +5,23 @@ import dotenv = require('dotenv');
 
 import { startBumpScheduler } from './schedulers/bump_scheduler';
 import { initializeCommands } from './client/initial_commands';
+import { initializeRoleplayProxy } from './client/rp_proxy_events';
 import { initializeDB, testPgConnection } from './db/db';
 
 dotenv.config();
 
 const client = new Client({
-  intents: [GatewayIntentBits.Guilds],
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+  ],
 });
 
 async function main(): Promise<void> {
   try {
     await initializeCommands(client);
+    initializeRoleplayProxy(client);
     await testPgConnection();
     await initializeDB();
     await client.login(process.env.DISCORD_BOT_TOKEN);

--- a/src/services/character.service.ts
+++ b/src/services/character.service.ts
@@ -26,6 +26,8 @@ export async function createCharacter({
   gameId,
   name,
   avatar_url = null,
+  rp_display_name = null,
+  rp_display_avatar_url = null,
   bio = null,
   visibility = 'private',
   stats = {},
@@ -36,6 +38,8 @@ export async function createCharacter({
   gameId: string;
   name: string;
   avatar_url?: string | null;
+  rp_display_name?: string | null;
+  rp_display_avatar_url?: string | null;
   bio?: string | null;
   visibility?: 'public' | 'private';
   stats?: Record<string, string | StatFieldEntry>;
@@ -46,6 +50,8 @@ export async function createCharacter({
     game_id: gameId,
     name,
     avatar_url,
+    rp_display_name,
+    rp_display_avatar_url,
     bio,
     visibility,
   });
@@ -139,6 +145,8 @@ export async function updateCharacterMeta(
   fields: Partial<{
     name: string;
     avatar_url: string | null;
+    rp_display_name: string | null;
+    rp_display_avatar_url: string | null;
     bio: string | null;
     visibility: 'public' | 'private';
   }>,
@@ -149,6 +157,8 @@ export async function updateCharacterMeta(
   const merged = {
     name: existing.name,
     avatar_url: existing.avatar_url,
+    rp_display_name: existing.rp_display_name,
+    rp_display_avatar_url: existing.rp_display_avatar_url,
     bio: existing.bio,
     visibility: existing.visibility,
     ...fields,

--- a/src/services/character_draft.service.ts
+++ b/src/services/character_draft.service.ts
@@ -140,6 +140,8 @@ export async function finalizeCharacterCreation(userId: string, draft: Character
 
   const name = draft.data['core:name']?.trim();
   const avatar_url = draft.data['core:avatar_url']?.trim() || null;
+  const rp_display_name = draft.data['core:rp_display_name']?.trim() || null;
+  const rp_display_avatar_url = draft.data['core:rp_display_avatar_url']?.trim() || null;
   const bio = draft.data['core:bio']?.trim() || null;
   const visibility = draft.data['core:visibility'] || 'private';
 
@@ -148,6 +150,8 @@ export async function finalizeCharacterCreation(userId: string, draft: Character
     game_id,
     name,
     avatar_url,
+    rp_display_name,
+    rp_display_avatar_url,
     bio,
     visibility,
   });

--- a/src/services/rp_channel_mode.service.ts
+++ b/src/services/rp_channel_mode.service.ts
@@ -1,0 +1,21 @@
+import { RpChannelModeDAO } from '../dao/rp_channel_mode.dao';
+
+const rpChannelModeDAO = new RpChannelModeDAO();
+
+export async function setChannelInCharacterMode({
+  guildId,
+  channelId,
+  isIc,
+  updatedBy,
+}: {
+  guildId: string;
+  channelId: string;
+  isIc: boolean;
+  updatedBy: string;
+}) {
+  return rpChannelModeDAO.setMode({ guildId, channelId, isIc, updatedBy });
+}
+
+export async function isChannelInCharacter(guildId: string, channelId: string): Promise<boolean> {
+  return rpChannelModeDAO.isInCharacter(guildId, channelId);
+}

--- a/src/services/rp_message_proxy.service.ts
+++ b/src/services/rp_message_proxy.service.ts
@@ -1,0 +1,154 @@
+import type {
+  APIEmbed,
+  Attachment,
+  Collection,
+  Message,
+  TextBasedChannel,
+  Webhook,
+} from 'discord.js';
+
+import { CharacterDAO } from '../dao/character.dao';
+import { PlayerDAO } from '../dao/player.dao';
+import { RP_PROXY_TOTAL_CHARACTER_LIMIT, splitRpMessage } from '../utils/rp_message_limits';
+import { isChannelInCharacter } from './rp_channel_mode.service';
+
+const RP_PROXY_WEBHOOK_NAME = 'Spritebot RP Proxy';
+const MESSAGE_TEXT_ATTACHMENT_NAME = 'message.txt';
+
+const characterDAO = new CharacterDAO();
+const playerDAO = new PlayerDAO();
+
+interface ProxyCharacter {
+  name?: string | null;
+  avatar_url?: string | null;
+  rp_display_name?: string | null;
+  rp_display_avatar_url?: string | null;
+}
+
+export type RpProxyResult =
+  | { status: 'ignored'; reason: string }
+  | { status: 'proxied'; chunks: number }
+  | { status: 'too_long'; length: number }
+  | { status: 'failed'; reason: string };
+
+type WebhookCapableChannel = TextBasedChannel & {
+  fetchWebhooks(): Promise<Collection<string, Webhook>>;
+  createWebhook(options: { name: string; reason?: string }): Promise<Webhook>;
+};
+
+function isWebhookCapableChannel(channel: TextBasedChannel): channel is WebhookCapableChannel {
+  return 'fetchWebhooks' in channel && 'createWebhook' in channel;
+}
+
+function getProxyDisplay(character: ProxyCharacter): { username: string; avatarURL?: string } {
+  const username = String(character.rp_display_name || character.name || 'Character').slice(0, 80);
+  const avatarURL = character.rp_display_avatar_url || character.avatar_url || undefined;
+
+  return { username, avatarURL };
+}
+
+function getNonTextAttachmentFiles(message: Message) {
+  return message.attachments
+    .filter((attachment) => attachment.name !== MESSAGE_TEXT_ATTACHMENT_NAME)
+    .map((attachment) => ({
+      attachment: attachment.url,
+      name: attachment.name ?? undefined,
+    }));
+}
+
+async function readMessageTextAttachment(attachment: Attachment): Promise<string> {
+  const response = await fetch(attachment.url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${MESSAGE_TEXT_ATTACHMENT_NAME}: ${response.status}`);
+  }
+
+  return response.text();
+}
+
+async function getMessageContent(message: Message): Promise<string> {
+  const inlineContent = message.content?.trim() ?? '';
+  const textAttachment = message.attachments.find(
+    (attachment) => attachment.name === MESSAGE_TEXT_ATTACHMENT_NAME,
+  );
+
+  if (!textAttachment) return inlineContent;
+
+  const attachmentText = (await readMessageTextAttachment(textAttachment)).trim();
+  return [inlineContent, attachmentText].filter(Boolean).join('\n\n');
+}
+
+async function getOrCreateProxyWebhook(channel: WebhookCapableChannel): Promise<Webhook> {
+  const webhooks = await channel.fetchWebhooks();
+  const existing = webhooks.find((webhook) => webhook.name === RP_PROXY_WEBHOOK_NAME);
+  if (existing) return existing;
+
+  return channel.createWebhook({
+    name: RP_PROXY_WEBHOOK_NAME,
+    reason: 'Spritebot roleplay proxy messages',
+  });
+}
+
+export async function handleRoleplayProxyMessage(message: Message): Promise<RpProxyResult> {
+  if (message.author.bot || message.webhookId) return { status: 'ignored', reason: 'bot' };
+  if (!message.guildId || !message.guild) return { status: 'ignored', reason: 'not_guild' };
+  if (!isWebhookCapableChannel(message.channel)) {
+    return { status: 'ignored', reason: 'channel_cannot_webhook' };
+  }
+
+  const isIc = await isChannelInCharacter(message.guildId, message.channelId);
+  if (!isIc) return { status: 'ignored', reason: 'ooc_channel' };
+
+  const activeCharacterId = await playerDAO.getCurrentCharacter(message.author.id, message.guildId);
+  if (!activeCharacterId) {
+    await message.reply({
+      content:
+        'This channel is in-character, but you do not have an active character selected. Use `/switch-character` first.',
+      allowedMentions: { parse: [] },
+    });
+    return { status: 'failed', reason: 'no_active_character' };
+  }
+
+  const character = await characterDAO.findById(activeCharacterId);
+  if (!character) {
+    await message.reply({
+      content:
+        'This channel is in-character, but I could not find your active character. Use `/switch-character` to select one again.',
+      allowedMentions: { parse: [] },
+    });
+    return { status: 'failed', reason: 'character_not_found' };
+  }
+
+  const content = await getMessageContent(message);
+  const files = getNonTextAttachmentFiles(message);
+  if (!content && files.length === 0 && message.embeds.length === 0) {
+    return { status: 'ignored', reason: 'empty_message' };
+  }
+
+  if (content.length > RP_PROXY_TOTAL_CHARACTER_LIMIT) {
+    await message.reply({
+      content: `This RP post is ${content.length} characters, but the IC proxy limit is ${RP_PROXY_TOTAL_CHARACTER_LIMIT}. I left your original message in place so you can edit and repost it.`,
+      allowedMentions: { parse: [] },
+    });
+    return { status: 'too_long', length: content.length };
+  }
+
+  const chunks = splitRpMessage(content);
+  const webhook = await getOrCreateProxyWebhook(message.channel);
+  const display = getProxyDisplay(character);
+  const embeds = message.embeds.map((embed) => embed.toJSON() as APIEmbed);
+  const sends = chunks.length ? chunks : [''];
+
+  for (let index = 0; index < sends.length; index++) {
+    await webhook.send({
+      content: sends[index],
+      username: display.username,
+      avatarURL: display.avatarURL,
+      files: index === 0 ? files : [],
+      embeds: index === 0 ? embeds : [],
+      allowedMentions: { parse: [] },
+    });
+  }
+
+  await message.delete();
+  return { status: 'proxied', chunks: sends.length };
+}

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -18,6 +18,8 @@ export interface Character {
   user_id: string;
   name: string;
   avatar_url?: string | null;
+  rp_display_name?: string | null;
+  rp_display_avatar_url?: string | null;
   bio?: string | null;
   visibility?: 'public' | 'private';
   created_at?: string;

--- a/src/utils/rebuild_create_character_response.ts
+++ b/src/utils/rebuild_create_character_response.ts
@@ -60,6 +60,24 @@ function buildCreateCharacterMessage(
     }
   }
 
+  const rpFields = ['core:rp_display_name', 'core:rp_display_avatar_url'];
+  lines.push('');
+  lines.push(`**RP Proxy Fields:** optional`);
+
+  for (const key of rpFields) {
+    const value = draftData[key];
+    const label = key
+      .split(':')[1]
+      .replace(/^rp_/, 'RP ')
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+    if (value && value.toString().trim()) {
+      lines.push(`- [CORE] ${label} 🟢 ${summarize(value.toString())}`);
+    } else {
+      lines.push(`- [CORE] ${label}`);
+    }
+  }
+
   lines.push('');
 
   if (statTemplates.length) {
@@ -165,6 +183,8 @@ function rebuildCreateCharacterResponse(
   const allFields: CustomField[] = [
     { name: 'core:name', label: '[CORE] Name' },
     { name: 'core:avatar_url', label: '[CORE] Avatar URL' },
+    { name: 'core:rp_display_name', label: '[CORE] RP Display Name' },
+    { name: 'core:rp_display_avatar_url', label: '[CORE] RP Display Avatar URL' },
     { name: 'core:bio', label: '[CORE] Bio' },
     ...statTemplates.map((t) => ({
       name: `game:${t.id}`,

--- a/src/utils/rp_message_limits.ts
+++ b/src/utils/rp_message_limits.ts
@@ -1,0 +1,35 @@
+export const RP_PROXY_CHUNK_CHARACTER_LIMIT = 2000;
+export const RP_PROXY_TOTAL_CHARACTER_LIMIT = 4000;
+
+export function splitRpMessage(
+  content: string,
+  chunkLimit = RP_PROXY_CHUNK_CHARACTER_LIMIT,
+): string[] {
+  const normalized = content.trim();
+  if (!normalized) return [];
+  if (normalized.length <= chunkLimit) return [normalized];
+
+  const chunks: string[] = [];
+  let remaining = normalized;
+
+  while (remaining.length > chunkLimit) {
+    const breakpoint = findBreakpoint(remaining, chunkLimit);
+    const chunk = remaining.slice(0, breakpoint).trimEnd();
+    if (chunk) chunks.push(chunk);
+    remaining = remaining.slice(breakpoint).trimStart();
+  }
+
+  if (remaining) chunks.push(remaining);
+  return chunks;
+}
+
+function findBreakpoint(content: string, chunkLimit: number): number {
+  const slice = content.slice(0, chunkLimit + 1);
+  const candidates = [
+    slice.lastIndexOf('\n\n'),
+    slice.lastIndexOf('\n'),
+    slice.lastIndexOf(' '),
+  ].filter((index) => index > 0);
+
+  return candidates.length ? Math.max(...candidates) : chunkLimit;
+}

--- a/tests/integration/services/character.service.test.ts
+++ b/tests/integration/services/character.service.test.ts
@@ -112,4 +112,34 @@ describe('character.service', () => {
       }),
     ]);
   });
+
+  test('persists roleplay display fields on character metadata', async () => {
+    const game = await createGame();
+
+    const character = await characterDAO.create({
+      user_id: 'player-1',
+      game_id: game.id,
+      name: 'Garnet Til Alexandros',
+      bio: null,
+      avatar_url: 'https://example.com/full-profile.png',
+      rp_display_name: 'Dagger',
+      rp_display_avatar_url: 'https://example.com/rp-avatar.png',
+    });
+
+    expect(character).toEqual(
+      expect.objectContaining({
+        rp_display_name: 'Dagger',
+        rp_display_avatar_url: 'https://example.com/rp-avatar.png',
+      }),
+    );
+
+    const hydrated = await getCharacterWithStats(character.id);
+
+    expect(hydrated).toEqual(
+      expect.objectContaining({
+        rp_display_name: 'Dagger',
+        rp_display_avatar_url: 'https://example.com/rp-avatar.png',
+      }),
+    );
+  });
 });

--- a/tests/integration/services/rp_channel_mode.service.test.ts
+++ b/tests/integration/services/rp_channel_mode.service.test.ts
@@ -1,0 +1,31 @@
+import {
+  isChannelInCharacter,
+  setChannelInCharacterMode,
+} from '../../../src/services/rp_channel_mode.service';
+
+describe('rp_channel_mode.service', () => {
+  test('defaults a channel to out-of-character', async () => {
+    await expect(isChannelInCharacter('guild-1', 'channel-1')).resolves.toBe(false);
+  });
+
+  test('toggles in-character mode per guild channel', async () => {
+    await setChannelInCharacterMode({
+      guildId: 'guild-1',
+      channelId: 'channel-1',
+      isIc: true,
+      updatedBy: 'gm-1',
+    });
+
+    await expect(isChannelInCharacter('guild-1', 'channel-1')).resolves.toBe(true);
+    await expect(isChannelInCharacter('guild-1', 'channel-2')).resolves.toBe(false);
+
+    await setChannelInCharacterMode({
+      guildId: 'guild-1',
+      channelId: 'channel-1',
+      isIc: false,
+      updatedBy: 'gm-1',
+    });
+
+    await expect(isChannelInCharacter('guild-1', 'channel-1')).resolves.toBe(false);
+  });
+});

--- a/tests/unit/utils/rp_message_limits.test.ts
+++ b/tests/unit/utils/rp_message_limits.test.ts
@@ -1,0 +1,31 @@
+import {
+  RP_PROXY_CHUNK_CHARACTER_LIMIT,
+  RP_PROXY_TOTAL_CHARACTER_LIMIT,
+  splitRpMessage,
+} from '../../../src/utils/rp_message_limits';
+
+describe('rp_message_limits', () => {
+  test('keeps short messages as a single chunk', () => {
+    expect(splitRpMessage('hello there')).toEqual(['hello there']);
+  });
+
+  test('splits messages above the Discord per-message cap', () => {
+    const content = `${'a'.repeat(RP_PROXY_CHUNK_CHARACTER_LIMIT)} ${'b'.repeat(50)}`;
+
+    const chunks = splitRpMessage(content);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].length).toBeLessThanOrEqual(RP_PROXY_CHUNK_CHARACTER_LIMIT);
+    expect(chunks[1]).toBe('b'.repeat(50));
+  });
+
+  test('supports the 4000 character Nitro-sized proxy cap in two chunks', () => {
+    const content = 'x'.repeat(RP_PROXY_TOTAL_CHARACTER_LIMIT);
+
+    const chunks = splitRpMessage(content);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks.join('')).toHaveLength(RP_PROXY_TOTAL_CHARACTER_LIMIT);
+    expect(chunks.every((chunk) => chunk.length <= RP_PROXY_CHUNK_CHARACTER_LIMIT)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds per-channel roleplay proxy mode with `/ic` and `/ooc`.

### Changes

- Added `/ic` to enable in-character proxy mode for the current channel.
- Added `/ooc` to disable proxy mode for the current channel.
- Added per-channel RP mode persistence via `rp_channel_mode`.
- Added character RP identity fields:
  - `rp_display_name`
  - `rp_display_avatar_url`
- Proxies IC messages through a managed Discord webhook using the active character.
- Falls back to character `name` / `avatar_url` when RP display fields are unset.
- Supports long RP posts by splitting messages into 2000-character webhook sends.
- Enforces a 4000-character total RP proxy cap.
- Supports `message.txt` text attachments as RP post input.
- Leaves the original message intact when extracted content exceeds 4000 characters.
- Deletes the original user message only after webhook proxying succeeds.
- Forwards non-`message.txt` attachments with the first proxied webhook message.

### Verification

- `npm run build`
- `npm test -- --runInBand`
- `npm run lint`

Note: lint passes with the repo’s existing warning baseline.

## After Deployment

1. Apply the DB migration:

```sql
\i src/db/tables/002_roleplay_proxy.sql