### PR TITLE
Add IC and OOC commands and support 2

### DIFF
--- a/src/commands/ic.ts
+++ b/src/commands/ic.ts
@@ -1,17 +1,11 @@
-import {
-  CacheType,
-  ChatInputCommandInteraction,
-  PermissionFlagsBits,
-  SlashCommandBuilder,
-} from 'discord.js';
+import { CacheType, ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
-import { setChannelInCharacterMode } from '../services/rp_channel_mode.service';
+import { setUserChannelInCharacterMode } from '../services/rp_channel_mode.service';
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('ic')
-    .setDescription('Set this channel to in-character roleplay proxy mode.')
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+    .setDescription('Set your messages in this channel to in-character roleplay proxy mode.'),
 
   async execute(interaction: ChatInputCommandInteraction<CacheType>) {
     const { channelId, guildId, user } = interaction;
@@ -23,16 +17,16 @@ module.exports = {
       });
     }
 
-    await setChannelInCharacterMode({
+    await setUserChannelInCharacterMode({
       guildId,
       channelId,
+      userId: user.id,
       isIc: true,
-      updatedBy: user.id,
     });
 
     return interaction.reply({
       content:
-        '✅ This channel is now in-character. Player messages will proxy through their active character.',
+        '✅ You are now in-character in this channel. Your messages here will proxy through your active character.',
       ephemeral: true,
     });
   },

--- a/src/commands/ooc.ts
+++ b/src/commands/ooc.ts
@@ -1,17 +1,11 @@
-import {
-  CacheType,
-  ChatInputCommandInteraction,
-  PermissionFlagsBits,
-  SlashCommandBuilder,
-} from 'discord.js';
+import { CacheType, ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 
-import { setChannelInCharacterMode } from '../services/rp_channel_mode.service';
+import { setUserChannelInCharacterMode } from '../services/rp_channel_mode.service';
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('ooc')
-    .setDescription('Set this channel to out-of-character mode.')
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+    .setDescription('Set your messages in this channel to out-of-character mode.'),
 
   async execute(interaction: ChatInputCommandInteraction<CacheType>) {
     const { channelId, guildId, user } = interaction;
@@ -23,15 +17,16 @@ module.exports = {
       });
     }
 
-    await setChannelInCharacterMode({
+    await setUserChannelInCharacterMode({
       guildId,
       channelId,
+      userId: user.id,
       isIc: false,
-      updatedBy: user.id,
     });
 
     return interaction.reply({
-      content: '✅ This channel is now out-of-character. Messages will no longer be proxied.',
+      content:
+        '✅ You are now out-of-character in this channel. Your messages here will no longer be proxied.',
       ephemeral: true,
     });
   },

--- a/src/dao/rp_channel_mode.dao.ts
+++ b/src/dao/rp_channel_mode.dao.ts
@@ -3,8 +3,8 @@ import { query } from '../db/client';
 export interface RpChannelMode {
   guild_id: string;
   channel_id: string;
+  user_id: string;
   is_ic: boolean;
-  updated_by: string;
   updated_at: string;
 }
 
@@ -12,33 +12,32 @@ export class RpChannelModeDAO {
   async setMode({
     guildId,
     channelId,
+    userId,
     isIc,
-    updatedBy,
   }: {
     guildId: string;
     channelId: string;
+    userId: string;
     isIc: boolean;
-    updatedBy: string;
   }): Promise<RpChannelMode> {
     const sql = `
-      INSERT INTO rp_channel_mode (guild_id, channel_id, is_ic, updated_by)
+      INSERT INTO rp_channel_mode (guild_id, channel_id, user_id, is_ic)
       VALUES ($1, $2, $3, $4)
-      ON CONFLICT (guild_id, channel_id)
+      ON CONFLICT (guild_id, channel_id, user_id)
       DO UPDATE SET
         is_ic = EXCLUDED.is_ic,
-        updated_by = EXCLUDED.updated_by,
         updated_at = CURRENT_TIMESTAMP
       RETURNING *
     `;
 
-    const result = await query<RpChannelMode>(sql, [guildId, channelId, isIc, updatedBy]);
+    const result = await query<RpChannelMode>(sql, [guildId, channelId, userId, isIc]);
     return result.rows[0];
   }
 
-  async isInCharacter(guildId: string, channelId: string): Promise<boolean> {
+  async isInCharacter(guildId: string, channelId: string, userId: string): Promise<boolean> {
     const result = await query<{ is_ic: boolean }>(
-      `SELECT is_ic FROM rp_channel_mode WHERE guild_id = $1 AND channel_id = $2`,
-      [guildId, channelId],
+      `SELECT is_ic FROM rp_channel_mode WHERE guild_id = $1 AND channel_id = $2 AND user_id = $3`,
+      [guildId, channelId, userId],
     );
 
     return result.rows[0]?.is_ic ?? false;

--- a/src/db/tables/002_roleplay_proxy.sql
+++ b/src/db/tables/002_roleplay_proxy.sql
@@ -5,11 +5,11 @@ ALTER TABLE character
 CREATE TABLE IF NOT EXISTS rp_channel_mode (
   guild_id TEXT NOT NULL,
   channel_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
   is_ic BOOLEAN NOT NULL DEFAULT FALSE,
-  updated_by TEXT NOT NULL,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (guild_id, channel_id)
+  PRIMARY KEY (guild_id, channel_id, user_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_rp_channel_mode_guild_id
-  ON rp_channel_mode(guild_id);
+CREATE INDEX IF NOT EXISTS idx_rp_channel_mode_guild_channel
+  ON rp_channel_mode(guild_id, channel_id);

--- a/src/db/tables/003_roleplay_proxy_user_scope.sql
+++ b/src/db/tables/003_roleplay_proxy_user_scope.sql
@@ -1,0 +1,26 @@
+ALTER TABLE rp_channel_mode
+  ADD COLUMN IF NOT EXISTS user_id TEXT;
+
+UPDATE rp_channel_mode
+SET user_id = updated_by
+WHERE user_id IS NULL
+  AND updated_by IS NOT NULL;
+
+DELETE FROM rp_channel_mode WHERE user_id IS NULL;
+
+ALTER TABLE rp_channel_mode
+  ALTER COLUMN user_id SET NOT NULL;
+
+ALTER TABLE rp_channel_mode
+  DROP CONSTRAINT IF EXISTS rp_channel_mode_pkey;
+
+ALTER TABLE rp_channel_mode
+  ADD PRIMARY KEY (guild_id, channel_id, user_id);
+
+ALTER TABLE rp_channel_mode
+  DROP COLUMN IF EXISTS updated_by;
+
+DROP INDEX IF EXISTS idx_rp_channel_mode_guild_id;
+
+CREATE INDEX IF NOT EXISTS idx_rp_channel_mode_guild_channel
+  ON rp_channel_mode(guild_id, channel_id);

--- a/src/db/tables/tables.sql
+++ b/src/db/tables/tables.sql
@@ -50,10 +50,10 @@ CREATE TABLE character (
 CREATE TABLE rp_channel_mode (
   guild_id TEXT NOT NULL,
   channel_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
   is_ic BOOLEAN NOT NULL DEFAULT FALSE,
-  updated_by TEXT NOT NULL,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (guild_id, channel_id)
+  PRIMARY KEY (guild_id, channel_id, user_id)
 );
 
 -- === PLAYER ACCOUNTS (GLOBAL IDENTITY) ===
@@ -169,7 +169,7 @@ CREATE INDEX idx_game_guild_id ON game(guild_id);
 -- Character lookups
 CREATE INDEX idx_character_user_id ON character(user_id);
 CREATE INDEX idx_character_game_id ON character(game_id);
-CREATE INDEX idx_rp_channel_mode_guild_id ON rp_channel_mode(guild_id);
+CREATE INDEX idx_rp_channel_mode_guild_channel ON rp_channel_mode(guild_id, channel_id);
 
 -- Stat lookups
 CREATE INDEX idx_stat_character_id ON character_stat_field(character_id);

--- a/src/services/rp_channel_mode.service.ts
+++ b/src/services/rp_channel_mode.service.ts
@@ -2,20 +2,24 @@ import { RpChannelModeDAO } from '../dao/rp_channel_mode.dao';
 
 const rpChannelModeDAO = new RpChannelModeDAO();
 
-export async function setChannelInCharacterMode({
+export async function setUserChannelInCharacterMode({
   guildId,
   channelId,
+  userId,
   isIc,
-  updatedBy,
 }: {
   guildId: string;
   channelId: string;
+  userId: string;
   isIc: boolean;
-  updatedBy: string;
 }) {
-  return rpChannelModeDAO.setMode({ guildId, channelId, isIc, updatedBy });
+  return rpChannelModeDAO.setMode({ guildId, channelId, userId, isIc });
 }
 
-export async function isChannelInCharacter(guildId: string, channelId: string): Promise<boolean> {
-  return rpChannelModeDAO.isInCharacter(guildId, channelId);
+export async function isUserInCharacterForChannel(
+  guildId: string,
+  channelId: string,
+  userId: string,
+): Promise<boolean> {
+  return rpChannelModeDAO.isInCharacter(guildId, channelId, userId);
 }

--- a/src/services/rp_message_proxy.service.ts
+++ b/src/services/rp_message_proxy.service.ts
@@ -10,7 +10,7 @@ import type {
 import { CharacterDAO } from '../dao/character.dao';
 import { PlayerDAO } from '../dao/player.dao';
 import { RP_PROXY_TOTAL_CHARACTER_LIMIT, splitRpMessage } from '../utils/rp_message_limits';
-import { isChannelInCharacter } from './rp_channel_mode.service';
+import { isUserInCharacterForChannel } from './rp_channel_mode.service';
 
 const RP_PROXY_WEBHOOK_NAME = 'Spritebot RP Proxy';
 const MESSAGE_TEXT_ATTACHMENT_NAME = 'message.txt';
@@ -95,14 +95,18 @@ export async function handleRoleplayProxyMessage(message: Message): Promise<RpPr
     return { status: 'ignored', reason: 'channel_cannot_webhook' };
   }
 
-  const isIc = await isChannelInCharacter(message.guildId, message.channelId);
-  if (!isIc) return { status: 'ignored', reason: 'ooc_channel' };
+  const isIc = await isUserInCharacterForChannel(
+    message.guildId,
+    message.channelId,
+    message.author.id,
+  );
+  if (!isIc) return { status: 'ignored', reason: 'user_ooc_in_channel' };
 
   const activeCharacterId = await playerDAO.getCurrentCharacter(message.author.id, message.guildId);
   if (!activeCharacterId) {
     await message.reply({
       content:
-        'This channel is in-character, but you do not have an active character selected. Use `/switch-character` first.',
+        'You are in-character in this channel, but you do not have an active character selected. Use `/switch-character` first.',
       allowedMentions: { parse: [] },
     });
     return { status: 'failed', reason: 'no_active_character' };
@@ -112,7 +116,7 @@ export async function handleRoleplayProxyMessage(message: Message): Promise<RpPr
   if (!character) {
     await message.reply({
       content:
-        'This channel is in-character, but I could not find your active character. Use `/switch-character` to select one again.',
+        'You are in-character in this channel, but I could not find your active character. Use `/switch-character` to select one again.',
       allowedMentions: { parse: [] },
     });
     return { status: 'failed', reason: 'character_not_found' };

--- a/tests/integration/services/rp_channel_mode.service.test.ts
+++ b/tests/integration/services/rp_channel_mode.service.test.ts
@@ -1,31 +1,40 @@
 import {
-  isChannelInCharacter,
-  setChannelInCharacterMode,
+  isUserInCharacterForChannel,
+  setUserChannelInCharacterMode,
 } from '../../../src/services/rp_channel_mode.service';
 
 describe('rp_channel_mode.service', () => {
-  test('defaults a channel to out-of-character', async () => {
-    await expect(isChannelInCharacter('guild-1', 'channel-1')).resolves.toBe(false);
+  test('defaults a user in a channel to out-of-character', async () => {
+    await expect(isUserInCharacterForChannel('guild-1', 'channel-1', 'user-1')).resolves.toBe(
+      false,
+    );
   });
 
-  test('toggles in-character mode per guild channel', async () => {
-    await setChannelInCharacterMode({
+  test('toggles in-character mode per user per guild channel', async () => {
+    await setUserChannelInCharacterMode({
       guildId: 'guild-1',
       channelId: 'channel-1',
+      userId: 'user-1',
       isIc: true,
-      updatedBy: 'gm-1',
     });
 
-    await expect(isChannelInCharacter('guild-1', 'channel-1')).resolves.toBe(true);
-    await expect(isChannelInCharacter('guild-1', 'channel-2')).resolves.toBe(false);
+    await expect(isUserInCharacterForChannel('guild-1', 'channel-1', 'user-1')).resolves.toBe(true);
+    await expect(isUserInCharacterForChannel('guild-1', 'channel-1', 'user-2')).resolves.toBe(
+      false,
+    );
+    await expect(isUserInCharacterForChannel('guild-1', 'channel-2', 'user-1')).resolves.toBe(
+      false,
+    );
 
-    await setChannelInCharacterMode({
+    await setUserChannelInCharacterMode({
       guildId: 'guild-1',
       channelId: 'channel-1',
+      userId: 'user-1',
       isIc: false,
-      updatedBy: 'gm-1',
     });
 
-    await expect(isChannelInCharacter('guild-1', 'channel-1')).resolves.toBe(false);
+    await expect(isUserInCharacterForChannel('guild-1', 'channel-1', 'user-1')).resolves.toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
Corrected the feature to be **per-player per-channel**, not channel-wide.

Now:

- `/ic` affects only the user who runs it, in that channel.
- `/ooc` affects only the user who runs it, in that channel.
- Other players in the same channel stay OOC unless they personally run `/ic`.
- Removed the `ManageChannels` permission requirement from both commands.
- Proxy lookup now checks `guild_id + channel_id + user_id`.
- Added `003_roleplay_proxy_user_scope.sql` to convert the earlier channel-wide table shape.

Verification passed:

- `npm run build`
- `npm test -- --runInBand`
- `npm run lint` passes with the existing warning baseline

Important: Did **not** apply the corrective remote DB migration yet, because the running app may still be on the previous code. Deploy the corrected code and apply `src/db/tables/003_roleplay_proxy_user_scope.sql` as part of that rollout.