### PR TITLE
Add IC and OOC commands and support 3 + 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ At a high level, the bot supports:
 - Creating and editing characters through Discord components and modals
 - Viewing character sheets and public characters
 - Managing character inventory
+- Letting players proxy in-character posts through webhooks with `/ic` and `/ooc`
 - Auto-bumping registered Discord threads on a schedule
 - Restricting certain commands behind subscription/entitlement checks
 
@@ -33,6 +34,10 @@ The repo currently defines these slash commands:
 - `/view-character` - View your active character
 - `/list-characters` - List public characters in the active game
 - `/switch-character` - Switch your active character
+- `/ic` - Set your messages in the current channel to in-character proxy mode
+- `/ooc` - Set your messages in the current channel to out-of-character mode
+- `/ic-edit` - Edit one of your tracked proxied in-character messages
+- `/ic-delete` - Delete one of your tracked proxied in-character messages
 - `/inventory` - View and manage inventory for your active character
 - `/bump-thread` - Register and manage auto-bumped threads
 - `/gift` - Ops-only gifted access management
@@ -72,6 +77,23 @@ They also include game-defined stat fields and optional custom fields.
 ### Inventory
 
 Each character can have inventory entries, along with per-item custom fields stored separately in the database.
+
+### Roleplay Proxy
+
+Players can use `/ic` and `/ooc` to toggle whether their own messages in the current channel should be proxied through a Discord webhook as their active character.
+
+This state is scoped per player and per channel. One player can be IC in a channel while another remains OOC.
+
+When proxying, the bot uses the character's optional RP display fields first:
+
+- RP Display Name
+- RP Display Avatar URL
+
+If those fields are blank, it falls back to the character's normal name and avatar URL.
+
+Spritebot tracks the ownership of every proxied webhook message. Players can pass a proxied message ID or Discord message link to `/ic-edit` or `/ic-delete`, and the bot will only update/delete the message if it was originally proxied by that same Discord user.
+
+For split RP posts, each chunk is a separate proxied Discord message and can be edited or deleted by its own message ID/link.
 
 ### Thread Bumps
 
@@ -118,6 +140,8 @@ Primary tables include:
 - `character_custom_field`
 - `character_inventory`
 - `character_inventory_field`
+- `rp_channel_mode`
+- `rp_proxy_message`
 - `thread_bumps`
 - `entitlements_cache`
 - `gifted_guilds`
@@ -187,7 +211,69 @@ Notes:
 - `OWNER_DISCORD_ID` is used by `/gift` and `/toggle-bypass`
 - production DB auto-init is disabled unless `ALLOW_DB_INIT=true`
 
-### 3. Run the bot in development
+### 3. Discord application setup
+
+Invite the bot with these OAuth2 scopes:
+
+- `bot`
+- `applications.commands`
+
+Enable these gateway intents in code and in the Discord Developer Portal:
+
+- `Guilds`
+- `Guild Messages`
+- `Message Content`
+
+`Message Content` is required for the RP proxy feature because the bot must read a player's message before reposting it through the character webhook.
+
+### 4. Discord server permissions
+
+At minimum, Spritebot needs these permissions in any channel where slash-command UI should work:
+
+- View Channel
+- Use Application Commands
+- Send Messages
+- Embed Links
+- Read Message History
+
+For character sheets, game setup, inventory, buttons, selects, and modals, no elevated server permissions are expected beyond normal interaction access.
+
+RP proxy channels need additional permissions:
+
+- Manage Webhooks
+- Manage Messages
+- Attach Files
+
+Why:
+
+- Manage Webhooks lets Spritebot fetch or create the channel webhook used to post as a character.
+- Manage Messages lets Spritebot delete the original user message after the webhook post succeeds.
+- Attach Files lets Spritebot forward non-`message.txt` attachments with the first proxied message.
+
+Thread bump channels need thread-specific permissions:
+
+- Send Messages in Threads
+- Manage Threads
+- Read Message History
+
+Why:
+
+- Send Messages in Threads lets Spritebot post bump messages.
+- Manage Threads lets Spritebot unarchive locked/archived threads before bumping.
+- Read Message History lets the archive-aware scheduler inspect recent thread activity.
+
+Ops-only commands:
+
+- `/gift` and `/toggle-bypass` are registered only in `DEV_GUILD_ID`.
+- They are Discord administrator commands and also check `OWNER_DISCORD_ID`.
+
+Recommended setup:
+
+- Grant the baseline permissions server-wide or at the category level where Spritebot is used.
+- Grant RP proxy permissions only in channels/categories where players should use `/ic`.
+- Grant thread permissions only in categories containing threads that Spritebot should auto-bump.
+
+### 5. Run the bot in development
 
 ```bash
 npm run start:dev
@@ -201,7 +287,7 @@ On startup, the app will:
 - log in the bot client
 - start the thread bump scheduler
 
-### 4. Build for production
+### 6. Build for production
 
 ```bash
 npm run build

--- a/src/commands/ic-delete.ts
+++ b/src/commands/ic-delete.ts
@@ -1,0 +1,67 @@
+import { CacheType, ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+
+import { deleteRoleplayProxyMessage } from '../services/rp_message_proxy.service';
+import { parseDiscordMessageReference } from '../utils/discord_message_reference';
+
+function resultMessage(status: string, reason?: string): string {
+  if (status === 'deleted') return '🗑️ Deleted your proxied RP message.';
+  if (status === 'forbidden') return '⛔ You can only delete your own proxied RP messages.';
+  if (status === 'not_found') {
+    return '⚠️ I could not find a tracked proxied RP message for that ID or link.';
+  }
+  if (status === 'failed' && reason === 'webhook_not_found') {
+    return '⚠️ I could not find the webhook that created that proxied message.';
+  }
+  if (status === 'failed' && reason === 'channel_cannot_webhook') {
+    return '⚠️ That channel cannot be managed through RP webhooks.';
+  }
+
+  return '❌ Failed to delete that proxied RP message.';
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ic-delete')
+    .setDescription('Delete one of your proxied in-character messages.')
+    .addStringOption((option) =>
+      option
+        .setName('message')
+        .setDescription('The proxied message ID or message link')
+        .setRequired(true),
+    ),
+
+  async execute(interaction: ChatInputCommandInteraction<CacheType>) {
+    const { channelId, guildId, user } = interaction;
+
+    if (!guildId) {
+      return interaction.reply({
+        content: '⚠️ This command must be used in a server.',
+        ephemeral: true,
+      });
+    }
+
+    const reference = parseDiscordMessageReference(
+      interaction.options.getString('message', true),
+      channelId,
+    );
+    if (!reference || (reference.guildId && reference.guildId !== guildId)) {
+      return interaction.reply({
+        content: '⚠️ Provide a valid message ID or a message link from this server.',
+        ephemeral: true,
+      });
+    }
+
+    const result = await deleteRoleplayProxyMessage({
+      client: interaction.client,
+      guildId,
+      channelId: reference.channelId,
+      userId: user.id,
+      messageId: reference.messageId,
+    });
+
+    return interaction.reply({
+      content: resultMessage(result.status, 'reason' in result ? result.reason : undefined),
+      ephemeral: true,
+    });
+  },
+};

--- a/src/commands/ic-edit.ts
+++ b/src/commands/ic-edit.ts
@@ -1,0 +1,81 @@
+import { CacheType, ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+
+import { editRoleplayProxyMessage } from '../services/rp_message_proxy.service';
+import { parseDiscordMessageReference } from '../utils/discord_message_reference';
+
+function resultMessage(status: string, reason?: string): string {
+  if (status === 'updated') return '✅ Updated your proxied RP message.';
+  if (status === 'forbidden') return '⛔ You can only edit your own proxied RP messages.';
+  if (status === 'not_found') {
+    return '⚠️ I could not find a tracked proxied RP message for that ID or link.';
+  }
+  if (status === 'invalid_content' && reason === 'empty') {
+    return '⚠️ Replacement content cannot be empty.';
+  }
+  if (status === 'invalid_content' && reason === 'too_long') {
+    return '⚠️ Replacement content must be 2000 characters or fewer.';
+  }
+  if (status === 'failed' && reason === 'webhook_not_found') {
+    return '⚠️ I could not find the webhook that created that proxied message.';
+  }
+  if (status === 'failed' && reason === 'channel_cannot_webhook') {
+    return '⚠️ That channel cannot be managed through RP webhooks.';
+  }
+
+  return '❌ Failed to update that proxied RP message.';
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ic-edit')
+    .setDescription('Edit one of your proxied in-character messages.')
+    .addStringOption((option) =>
+      option
+        .setName('message')
+        .setDescription('The proxied message ID or message link')
+        .setRequired(true),
+    )
+    .addStringOption((option) =>
+      option
+        .setName('content')
+        .setDescription('Replacement message content')
+        .setRequired(true)
+        .setMaxLength(2000),
+    ),
+
+  async execute(interaction: ChatInputCommandInteraction<CacheType>) {
+    const { channelId, guildId, user } = interaction;
+
+    if (!guildId) {
+      return interaction.reply({
+        content: '⚠️ This command must be used in a server.',
+        ephemeral: true,
+      });
+    }
+
+    const reference = parseDiscordMessageReference(
+      interaction.options.getString('message', true),
+      channelId,
+    );
+    if (!reference || (reference.guildId && reference.guildId !== guildId)) {
+      return interaction.reply({
+        content: '⚠️ Provide a valid message ID or a message link from this server.',
+        ephemeral: true,
+      });
+    }
+
+    const result = await editRoleplayProxyMessage({
+      client: interaction.client,
+      guildId,
+      channelId: reference.channelId,
+      userId: user.id,
+      messageId: reference.messageId,
+      content: interaction.options.getString('content', true),
+    });
+
+    return interaction.reply({
+      content: resultMessage(result.status, 'reason' in result ? result.reason : undefined),
+      ephemeral: true,
+    });
+  },
+};

--- a/src/dao/rp_proxy_message.dao.ts
+++ b/src/dao/rp_proxy_message.dao.ts
@@ -1,0 +1,79 @@
+import { query } from '../db/client';
+
+export interface RpProxyMessage {
+  proxy_message_id: string;
+  guild_id: string;
+  channel_id: string;
+  user_id: string;
+  character_id: string | null;
+  webhook_id: string;
+  chunk_index: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export class RpProxyMessageDAO {
+  async create(input: {
+    proxyMessageId: string;
+    guildId: string;
+    channelId: string;
+    userId: string;
+    characterId: string | null;
+    webhookId: string;
+    chunkIndex: number;
+  }): Promise<RpProxyMessage> {
+    const sql = `
+      INSERT INTO rp_proxy_message (
+        proxy_message_id,
+        guild_id,
+        channel_id,
+        user_id,
+        character_id,
+        webhook_id,
+        chunk_index
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      ON CONFLICT (proxy_message_id)
+      DO UPDATE SET
+        guild_id = EXCLUDED.guild_id,
+        channel_id = EXCLUDED.channel_id,
+        user_id = EXCLUDED.user_id,
+        character_id = EXCLUDED.character_id,
+        webhook_id = EXCLUDED.webhook_id,
+        chunk_index = EXCLUDED.chunk_index,
+        updated_at = CURRENT_TIMESTAMP
+      RETURNING *
+    `;
+
+    const result = await query<RpProxyMessage>(sql, [
+      input.proxyMessageId,
+      input.guildId,
+      input.channelId,
+      input.userId,
+      input.characterId,
+      input.webhookId,
+      input.chunkIndex,
+    ]);
+    return result.rows[0];
+  }
+
+  async findByMessageId(messageId: string): Promise<RpProxyMessage | null> {
+    const result = await query<RpProxyMessage>(
+      `SELECT * FROM rp_proxy_message WHERE proxy_message_id = $1`,
+      [messageId],
+    );
+
+    return result.rows[0] ?? null;
+  }
+
+  async touch(messageId: string): Promise<void> {
+    await query(
+      `UPDATE rp_proxy_message SET updated_at = CURRENT_TIMESTAMP WHERE proxy_message_id = $1`,
+      [messageId],
+    );
+  }
+
+  async delete(messageId: string): Promise<void> {
+    await query(`DELETE FROM rp_proxy_message WHERE proxy_message_id = $1`, [messageId]);
+  }
+}

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -165,6 +165,7 @@ export async function resetDb(): Promise<void> {
     'character_inventory',
     'character_custom_field',
     'character_stat_field',
+    'rp_proxy_message',
     'player_server_link',
     'player',
     'character',

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -39,6 +39,7 @@ export async function initializeDB(): Promise<void> {
       'character_inventory_field',
       'thread_bumps', // <— NEW
       'rp_channel_mode',
+      'rp_proxy_message',
     ];
 
     // 🔍 Check which tables exist

--- a/src/db/tables/004_roleplay_proxy_message_tracking.sql
+++ b/src/db/tables/004_roleplay_proxy_message_tracking.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS rp_proxy_message (
+  proxy_message_id TEXT PRIMARY KEY,
+  guild_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  character_id UUID REFERENCES character(id) ON DELETE SET NULL,
+  webhook_id TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_rp_proxy_message_user_id
+  ON rp_proxy_message(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_rp_proxy_message_channel_id
+  ON rp_proxy_message(channel_id);

--- a/src/db/tables/tables.sql
+++ b/src/db/tables/tables.sql
@@ -56,6 +56,19 @@ CREATE TABLE rp_channel_mode (
   PRIMARY KEY (guild_id, channel_id, user_id)
 );
 
+-- === ROLEPLAY PROXY MESSAGE OWNERSHIP ===
+CREATE TABLE rp_proxy_message (
+  proxy_message_id TEXT PRIMARY KEY,
+  guild_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  character_id UUID REFERENCES character(id) ON DELETE SET NULL,
+  webhook_id TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 -- === PLAYER ACCOUNTS (GLOBAL IDENTITY) ===
 CREATE TABLE player (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -170,6 +183,8 @@ CREATE INDEX idx_game_guild_id ON game(guild_id);
 CREATE INDEX idx_character_user_id ON character(user_id);
 CREATE INDEX idx_character_game_id ON character(game_id);
 CREATE INDEX idx_rp_channel_mode_guild_channel ON rp_channel_mode(guild_id, channel_id);
+CREATE INDEX idx_rp_proxy_message_user_id ON rp_proxy_message(user_id);
+CREATE INDEX idx_rp_proxy_message_channel_id ON rp_proxy_message(channel_id);
 
 -- Stat lookups
 CREATE INDEX idx_stat_character_id ON character_stat_field(character_id);

--- a/src/handlers/select_menu_handlers/character_stat_select_menu.ts
+++ b/src/handlers/select_menu_handlers/character_stat_select_menu.ts
@@ -54,7 +54,7 @@ export async function handle(interaction: StringSelectMenuInteraction): Promise<
     const inputStyle = coreField === 'bio' ? TextInputStyle.Paragraph : TextInputStyle.Short;
 
     const modal = new ModalBuilder()
-      .setCustomId(`editCharacterField:${characterId}:${selectedKey}|${label}`)
+      .setCustomId(`editCharacterField:${characterId}:${selectedKey}`)
       .setTitle(truncate(`Edit ${label}`))
       .addComponents(
         new ActionRowBuilder<TextInputBuilder>().addComponents(

--- a/src/services/rp_message_proxy.service.ts
+++ b/src/services/rp_message_proxy.service.ts
@@ -1,14 +1,8 @@
-import type {
-  APIEmbed,
-  Attachment,
-  Collection,
-  Message,
-  TextBasedChannel,
-  Webhook,
-} from 'discord.js';
+import type { APIEmbed, Attachment, Client, Collection, Message, Webhook } from 'discord.js';
 
 import { CharacterDAO } from '../dao/character.dao';
 import { PlayerDAO } from '../dao/player.dao';
+import { RpProxyMessageDAO } from '../dao/rp_proxy_message.dao';
 import { RP_PROXY_TOTAL_CHARACTER_LIMIT, splitRpMessage } from '../utils/rp_message_limits';
 import { isUserInCharacterForChannel } from './rp_channel_mode.service';
 
@@ -17,6 +11,7 @@ const MESSAGE_TEXT_ATTACHMENT_NAME = 'message.txt';
 
 const characterDAO = new CharacterDAO();
 const playerDAO = new PlayerDAO();
+const proxyMessageDAO = new RpProxyMessageDAO();
 
 interface ProxyCharacter {
   name?: string | null;
@@ -36,8 +31,15 @@ type WebhookCapableChannel = TextBasedChannel & {
   createWebhook(options: { name: string; reason?: string }): Promise<Webhook>;
 };
 
-function isWebhookCapableChannel(channel: TextBasedChannel): channel is WebhookCapableChannel {
-  return 'fetchWebhooks' in channel && 'createWebhook' in channel;
+type TextBasedChannel = Message['channel'];
+
+function isWebhookCapableChannel(channel: unknown): channel is WebhookCapableChannel {
+  return (
+    !!channel &&
+    typeof channel === 'object' &&
+    'fetchWebhooks' in channel &&
+    'createWebhook' in channel
+  );
 }
 
 function getProxyDisplay(character: ProxyCharacter): { username: string; avatarURL?: string } {
@@ -86,6 +88,101 @@ async function getOrCreateProxyWebhook(channel: WebhookCapableChannel): Promise<
     name: RP_PROXY_WEBHOOK_NAME,
     reason: 'Spritebot roleplay proxy messages',
   });
+}
+
+async function getExistingProxyWebhook(
+  channel: WebhookCapableChannel,
+  webhookId: string,
+): Promise<Webhook | null> {
+  const webhooks = await channel.fetchWebhooks();
+  return webhooks.get(webhookId) ?? null;
+}
+
+async function fetchWebhookCapableChannel(
+  client: Client,
+  channelId: string,
+): Promise<WebhookCapableChannel | null> {
+  const channel = await client.channels.fetch(channelId).catch(() => null);
+  return isWebhookCapableChannel(channel) ? channel : null;
+}
+
+export type RpProxyMutationResult =
+  | { status: 'updated' }
+  | { status: 'deleted' }
+  | { status: 'not_found' }
+  | { status: 'forbidden' }
+  | { status: 'invalid_content'; reason: string }
+  | { status: 'failed'; reason: string };
+
+export async function editRoleplayProxyMessage({
+  client,
+  guildId,
+  channelId,
+  userId,
+  messageId,
+  content,
+}: {
+  client: Client;
+  guildId: string;
+  channelId: string;
+  userId: string;
+  messageId: string;
+  content: string;
+}): Promise<RpProxyMutationResult> {
+  const trimmed = content.trim();
+  if (!trimmed) return { status: 'invalid_content', reason: 'empty' };
+  if (trimmed.length > 2000) return { status: 'invalid_content', reason: 'too_long' };
+
+  const record = await proxyMessageDAO.findByMessageId(messageId);
+  if (!record || record.guild_id !== guildId || record.channel_id !== channelId) {
+    return { status: 'not_found' };
+  }
+  if (record.user_id !== userId) return { status: 'forbidden' };
+
+  const channel = await fetchWebhookCapableChannel(client, record.channel_id);
+  if (!channel) return { status: 'failed', reason: 'channel_cannot_webhook' };
+
+  const webhook = await getExistingProxyWebhook(channel, record.webhook_id);
+  if (!webhook) return { status: 'failed', reason: 'webhook_not_found' };
+
+  await webhook.editMessage(record.proxy_message_id, {
+    content: trimmed,
+    allowedMentions: { parse: [] },
+  });
+  await proxyMessageDAO.touch(record.proxy_message_id);
+
+  return { status: 'updated' };
+}
+
+export async function deleteRoleplayProxyMessage({
+  client,
+  guildId,
+  channelId,
+  userId,
+  messageId,
+}: {
+  client: Client;
+  guildId: string;
+  channelId: string;
+  userId: string;
+  messageId: string;
+}): Promise<RpProxyMutationResult> {
+  const record = await proxyMessageDAO.findByMessageId(messageId);
+  if (!record || record.guild_id !== guildId || record.channel_id !== channelId) {
+    return { status: 'not_found' };
+  }
+  if (record.user_id !== userId) return { status: 'forbidden' };
+
+  const channel = await fetchWebhookCapableChannel(client, record.channel_id);
+  if (!channel) return { status: 'failed', reason: 'channel_cannot_webhook' };
+
+  const webhook = await getExistingProxyWebhook(channel, record.webhook_id);
+  if (!webhook) return { status: 'failed', reason: 'webhook_not_found' };
+
+  await webhook.deleteMessage(record.proxy_message_id);
+  await proxyMessageDAO.delete(record.proxy_message_id);
+
+  return { status: 'deleted' };
 }
 
 export async function handleRoleplayProxyMessage(message: Message): Promise<RpProxyResult> {
@@ -143,13 +240,22 @@ export async function handleRoleplayProxyMessage(message: Message): Promise<RpPr
   const sends = chunks.length ? chunks : [''];
 
   for (let index = 0; index < sends.length; index++) {
-    await webhook.send({
+    const sent = await webhook.send({
       content: sends[index],
       username: display.username,
       avatarURL: display.avatarURL,
       files: index === 0 ? files : [],
       embeds: index === 0 ? embeds : [],
       allowedMentions: { parse: [] },
+    });
+    await proxyMessageDAO.create({
+      proxyMessageId: sent.id,
+      guildId: message.guildId,
+      channelId: message.channelId,
+      userId: message.author.id,
+      characterId: activeCharacterId,
+      webhookId: webhook.id,
+      chunkIndex: index,
     });
   }
 

--- a/src/utils/discord_message_reference.ts
+++ b/src/utils/discord_message_reference.ts
@@ -1,0 +1,34 @@
+const DISCORD_MESSAGE_LINK =
+  /^https?:\/\/(?:(?:canary|ptb)\.)?discord(?:app)?\.com\/channels\/(?<guildId>\d+)\/(?<channelId>\d+)\/(?<messageId>\d+)$/;
+const SNOWFLAKE = /^\d{15,25}$/;
+
+export interface DiscordMessageReference {
+  guildId?: string;
+  channelId: string;
+  messageId: string;
+}
+
+export function parseDiscordMessageReference(
+  input: string,
+  fallbackChannelId: string,
+): DiscordMessageReference | null {
+  const trimmed = input.trim().replace(/^<|>$/g, '');
+  const linkMatch = trimmed.match(DISCORD_MESSAGE_LINK);
+
+  if (linkMatch?.groups?.channelId && linkMatch.groups.messageId) {
+    return {
+      guildId: linkMatch.groups.guildId,
+      channelId: linkMatch.groups.channelId,
+      messageId: linkMatch.groups.messageId,
+    };
+  }
+
+  if (SNOWFLAKE.test(trimmed)) {
+    return {
+      channelId: fallbackChannelId,
+      messageId: trimmed,
+    };
+  }
+
+  return null;
+}

--- a/tests/integration/dao/rp_proxy_message.dao.test.ts
+++ b/tests/integration/dao/rp_proxy_message.dao.test.ts
@@ -1,0 +1,62 @@
+import { CharacterDAO } from '../../../src/dao/character.dao';
+import { GameDAO } from '../../../src/dao/game.dao';
+import { RpProxyMessageDAO } from '../../../src/dao/rp_proxy_message.dao';
+
+describe('RpProxyMessageDAO', () => {
+  const gameDAO = new GameDAO();
+  const characterDAO = new CharacterDAO();
+  const rpProxyMessageDAO = new RpProxyMessageDAO();
+
+  async function createCharacter() {
+    const game = await gameDAO.create({
+      name: 'Message Ownership Campaign',
+      description: '',
+      created_by: 'gm-1',
+      guild_id: 'guild-1',
+    });
+
+    return characterDAO.create({
+      user_id: 'user-1',
+      game_id: game.id,
+      name: 'Ownership Hero',
+      avatar_url: null,
+      bio: null,
+    });
+  }
+
+  test('creates, updates, finds, touches, and deletes proxy ownership rows', async () => {
+    const character = await createCharacter();
+
+    const created = await rpProxyMessageDAO.create({
+      proxyMessageId: 'proxy-1',
+      guildId: 'guild-1',
+      channelId: 'channel-1',
+      userId: 'user-1',
+      characterId: character.id,
+      webhookId: 'webhook-1',
+      chunkIndex: 0,
+    });
+
+    expect(created).toEqual(
+      expect.objectContaining({
+        proxy_message_id: 'proxy-1',
+        guild_id: 'guild-1',
+        channel_id: 'channel-1',
+        user_id: 'user-1',
+        character_id: character.id,
+        webhook_id: 'webhook-1',
+        chunk_index: 0,
+      }),
+    );
+
+    await rpProxyMessageDAO.touch('proxy-1');
+    await expect(rpProxyMessageDAO.findByMessageId('proxy-1')).resolves.toEqual(
+      expect.objectContaining({
+        user_id: 'user-1',
+      }),
+    );
+
+    await rpProxyMessageDAO.delete('proxy-1');
+    await expect(rpProxyMessageDAO.findByMessageId('proxy-1')).resolves.toBeNull();
+  });
+});

--- a/tests/unit/utils/discord_message_reference.test.ts
+++ b/tests/unit/utils/discord_message_reference.test.ts
@@ -1,0 +1,27 @@
+import { parseDiscordMessageReference } from '../../../src/utils/discord_message_reference';
+
+describe('parseDiscordMessageReference', () => {
+  test('parses a raw message ID using the fallback channel', () => {
+    expect(parseDiscordMessageReference('123456789012345678', 'channel-1')).toEqual({
+      channelId: 'channel-1',
+      messageId: '123456789012345678',
+    });
+  });
+
+  test('parses a Discord message link', () => {
+    expect(
+      parseDiscordMessageReference(
+        'https://discord.com/channels/111111111111111111/222222222222222222/333333333333333333',
+        'fallback-channel',
+      ),
+    ).toEqual({
+      guildId: '111111111111111111',
+      channelId: '222222222222222222',
+      messageId: '333333333333333333',
+    });
+  });
+
+  test('rejects invalid references', () => {
+    expect(parseDiscordMessageReference('not-a-message', 'channel-1')).toBeNull();
+  });
+});


### PR DESCRIPTION
```markdown
## Summary

Adds IC roleplay proxy support with per-player channel toggles, RP display fields, ownership-tracked proxied messages, and edit/delete controls.

### Changes

- Added `/ic` and `/ooc` as per-player, per-channel RP proxy toggles.
- Added `/ic-edit` to edit one of your own proxied RP messages by message ID or message link.
- Added `/ic-delete` to delete one of your own proxied RP messages by message ID or message link.
- Added RP character fields:
  - `rp_display_name`
  - `rp_display_avatar_url`
- RP proxy display falls back to character `name` and `avatar_url` when RP fields are blank.
- Proxies IC messages through a managed Discord webhook.
- Tracks proxied webhook message ownership in `rp_proxy_message`.
- Prevents users from editing/deleting proxied posts they do not own.
- Supports `message.txt` as long-post input.
- Splits RP proxy posts into 2000-character webhook messages.
- Enforces a 4000-character total proxy limit.
- Leaves original over-limit posts in place so users can edit/retry.
- Deletes original user messages only after successful proxy dispatch.
- Updated README with RP proxy docs, command list, DB tables, gateway intents, and required Discord permissions.

### Migrations

Apply these in order if not already applied:

```sql
\i src/db/tables/002_roleplay_proxy.sql
\i src/db/tables/003_roleplay_proxy_user_scope.sql
\i src/db/tables/004_roleplay_proxy_message_tracking.sql
```

### Discord Setup

Required scopes:

- `bot`
- `applications.commands`

Required privileged intent:

- Message Content Intent

Required channel permissions for RP proxy:

- View Channel
- Use Application Commands
- Send Messages
- Embed Links
- Read Message History
- Manage Webhooks
- Manage Messages
- Attach Files

### Verification

- `npm run build`
- `npm test -- --runInBand`
- `npm run lint`

Note: lint passes with the repo’s existing warning baseline.
```