### PR TITLE
Unify character stat value formatting

### DIFF
--- a/src/components/calculate_character_stats_button.ts
+++ b/src/components/calculate_character_stats_button.ts
@@ -12,6 +12,7 @@ import {
 import { getCharacterWithStats } from '../services/character.service';
 import type { InteractionDispatchPolicy } from '../discord/interaction_dispatch';
 import type { DiscordInteractionResponder } from '../discord/interaction_responder';
+import { formatCharacterStatValue } from '../utils/character_stat_display';
 import { isActiveCharacter } from '../utils/is_active_character';
 
 const id = 'calculateCharacterStats';
@@ -86,10 +87,8 @@ async function handle(
   const options = adjustableStats.map((stat: StatField) => {
     const label = stat.label || 'Unnamed';
     const value = `adjust:${stat.template_id}`;
-    const desc =
-      stat.field_type === 'count'
-        ? `Current: ${stat.meta?.current ?? stat.meta?.max ?? 0} / ${stat.meta?.max ?? '?'}`
-        : `Current: ${stat.value ?? '??'}`;
+    const displayValue = formatCharacterStatValue(stat);
+    const desc = displayValue ? `Current: ${displayValue}` : 'No value set';
 
     return new StringSelectMenuOptionBuilder().setLabel(label).setValue(value).setDescription(desc);
   });

--- a/src/components/edit_character_stats_button.ts
+++ b/src/components/edit_character_stats_button.ts
@@ -13,6 +13,7 @@ import { getCharacterWithStats } from '../services/character.service';
 import type { InteractionDispatchPolicy } from '../discord/interaction_dispatch';
 import type { DiscordInteractionResponder } from '../discord/interaction_responder';
 import type { CharacterStatWithLabel } from '../types/character';
+import { formatCharacterStatValue } from '../utils/character_stat_display';
 import { isActiveCharacter } from '../utils/is_active_character';
 import { build as buildCharacterCard } from './view_character_card';
 
@@ -82,10 +83,11 @@ async function handle(
     )
     .map((stat: EditableStat) => {
       const identifier = stat.template_id || stat.name;
+      const currentValue = formatCharacterStatValue(stat);
       return {
         label: String(stat.label || identifier || 'Unnamed'),
         value: String(identifier),
-        description: stat.value != null ? truncate(`Current: ${stat.value}`) : 'No value set',
+        description: currentValue ? truncate(`Current: ${currentValue}`) : 'No value set',
       };
     });
 

--- a/src/components/rebuild_list_characters_response.ts
+++ b/src/components/rebuild_list_characters_response.ts
@@ -4,6 +4,7 @@ import { ActionRowBuilder, ButtonBuilder, StringSelectMenuBuilder } from 'discor
 
 import { getCharacterWithStats } from '../services/character.service';
 import { getCurrentCharacter } from '../services/player.service';
+import { formatCharacterStatValue } from '../utils/character_stat_display';
 import { formatTimeAgo } from '../utils/time_ago';
 
 import type { CharacterStatWithLabel } from '../types/character';
@@ -50,15 +51,12 @@ async function rebuildListCharactersResponse(
       const baseLabel = `${full.name} — ${formatTimeAgo(full.created_at || '')}`;
       const label = isActive ? `⭐ ${baseLabel} (ACTIVE)` : baseLabel;
 
-      const topStats = [...(full.stats || [])].slice(0, 4).map((stat: CharacterStatWithLabel) => {
-        if (stat.field_type === 'count') {
-          const current = stat.meta?.current ?? '?';
-          const max = stat.meta?.max ?? '?';
-          return `${stat.label}: ${current} / ${max}`;
-        } else {
-          return `${stat.label}: ${stat.value}`;
-        }
-      });
+      const topStats = [...(full.stats || [])]
+        .slice(0, 4)
+        .map(
+          (stat: CharacterStatWithLabel) =>
+            `${stat.label}: ${formatCharacterStatValue(stat) ?? 'Not set'}`,
+        );
 
       const description = topStats.join(' • ') || full.bio || 'No stats available';
 

--- a/src/components/switch_character_selector.ts
+++ b/src/components/switch_character_selector.ts
@@ -17,6 +17,7 @@ import { isActiveCharacter } from '../utils/is_active_character';
 import { appendNudge, buildNudge } from '../utils/onboarding_nudge';
 import type { InteractionDispatchPolicy } from '../discord/interaction_dispatch';
 import type { DiscordInteractionResponder } from '../discord/interaction_responder';
+import { formatCharacterStatValue } from '../utils/character_stat_display';
 import { build as buildCharacterCard } from './view_character_card';
 
 export const interactionPolicy = {
@@ -87,15 +88,7 @@ export async function build(
         return aOrder !== bOrder ? aOrder - bOrder : a.label.localeCompare(b.label);
       })
       .slice(0, 4)
-      .map((s) => {
-        if (s.field_type === 'count') {
-          const current = s.meta?.current ?? '?';
-          const max = s.meta?.max ?? '?';
-          return `${s.label}: ${current} / ${max}`;
-        } else {
-          return `${s.label}: ${s.value}`;
-        }
-      });
+      .map((stat) => `${stat.label}: ${formatCharacterStatValue(stat) ?? 'Not set'}`);
 
     const visibilityBadge = fullCharacter.visibility === 'public' ? '✅ Public' : '🔒 Private';
     const createdAt = fullCharacter.created_at

--- a/src/components/view_character_card.ts
+++ b/src/components/view_character_card.ts
@@ -2,6 +2,7 @@
 
 import { ActionRowBuilder, ButtonBuilder, EmbedBuilder } from 'discord.js';
 import type { CharacterWithStats } from '../types/character';
+import { formatCharacterStatValue } from '../utils/character_stat_display';
 import { formatTimeAgo } from '../utils/time_ago';
 import { build as buildCalculateStatsButton } from './calculate_character_stats_button';
 import { build as buildDeleteCharacterButton } from './delete_character_button';
@@ -113,8 +114,7 @@ function buildActionRow(character: CharacterWithStats) {
 interface ParsedStat {
   label: string;
   value: string | null;
-  current: number | null;
-  max: number | null;
+  displayValue: string | null;
   type: string;
   sort_index: number;
 }
@@ -123,27 +123,17 @@ function parseCharacterStats(stats: CharacterWithStats['stats']) {
   const statMap = new Map<string, ParsedStat>();
 
   for (const stat of stats) {
-    const { label, value, meta = {}, field_type, template_id } = stat;
+    const { label, value, field_type, template_id } = stat;
     const key = (label || template_id || '??').toUpperCase();
     if (!key) continue;
 
     const bucket: ParsedStat = {
       label: key,
-      value: null,
-      current: null,
-      max: null,
+      value: field_type === 'count' ? null : (value ?? null),
+      displayValue: formatCharacterStatValue(stat),
       type: field_type,
       sort_index: stat.sort_index ?? 999,
     };
-
-    if (field_type === 'count') {
-      const max = typeof meta.max === 'number' ? meta.max : null;
-      const current = typeof meta.current === 'number' ? meta.current : max;
-      bucket.max = max;
-      bucket.current = current;
-    } else {
-      bucket.value = value ?? null;
-    }
 
     statMap.set(key, bucket);
   }
@@ -167,13 +157,7 @@ function parseCharacterStats(stats: CharacterWithStats['stats']) {
 }
 
 function formatStatDisplay(stat: ParsedStat): string {
-  if (stat.type === 'count' && stat.max !== null) {
-    return `**${stat.label}**: ${stat.current ?? stat.max} / ${stat.max}`;
-  } else if (stat.value !== undefined && stat.value !== null && stat.value !== '') {
-    return `**${stat.label}**: ${stat.value}`;
-  } else {
-    return `**${stat.label}**: _Not set_`;
-  }
+  return `**${stat.label}**: ${stat.displayValue ?? '_Not set_'}`;
 }
 
 function formatEquippedItems(character: CharacterWithStats): string | null {

--- a/src/utils/character_stat_display.ts
+++ b/src/utils/character_stat_display.ts
@@ -1,0 +1,23 @@
+import { formatCountStatValue } from './count_stat_defaults';
+
+interface CharacterStatDisplayInput {
+  field_type?: string | null;
+  value?: unknown;
+  meta?: Record<string, unknown> | null;
+}
+
+/**
+ * Formats a stored or draft character stat value consistently across Discord surfaces.
+ */
+function formatCharacterStatValue(stat: CharacterStatDisplayInput): string | null {
+  if (stat.field_type === 'count') {
+    return formatCountStatValue(stat.meta);
+  }
+
+  if (stat.value === null || stat.value === undefined) return null;
+  const value = String(stat.value).trim();
+  return value || null;
+}
+
+export { formatCharacterStatValue };
+export type { CharacterStatDisplayInput };

--- a/src/utils/count_stat_defaults.ts
+++ b/src/utils/count_stat_defaults.ts
@@ -34,6 +34,16 @@ function parseCountDefault(value: unknown): number | null {
   return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
+function formatCountStatValue(
+  meta: { current?: unknown; max?: unknown } | null | undefined,
+): string | null {
+  const max = parseCountDefault(meta?.max);
+  if (max === null) return null;
+
+  const current = parseCountDefault(meta?.current) ?? max;
+  return `${current} / ${max}`;
+}
+
 function getCountStatDefaults(
   template: Pick<StatTemplate, 'default_value' | 'meta'>,
 ): CountStatDefaults {
@@ -60,11 +70,12 @@ function formatStatTemplateDefault(template: StatTemplate): string | null {
   if (template.field_type !== 'count') return template.default_value;
 
   const defaults = getCountStatDefaults(template);
-  return defaults.max === null ? null : `${defaults.current} / ${defaults.max}`;
+  return formatCountStatValue(defaults);
 }
 
 export {
   applyCountStatDefaultsToDraft,
+  formatCountStatValue,
   formatStatTemplateDefault,
   getCountStatDefaults,
   parseCountDefault,

--- a/src/utils/rebuild_create_character_response.ts
+++ b/src/utils/rebuild_create_character_response.ts
@@ -8,6 +8,7 @@ import { build as rebuildEditFieldSelector } from '../components/edit_character_
 import { build as buildSubmitCharacterButton } from '../components/submit_character_button';
 import type { Game } from '../types/game';
 import type { StatTemplate } from '../types/stat_template';
+import { formatCharacterStatValue } from './character_stat_display';
 import {
   buildCharacterFieldOptions,
   getUnfilledCharacterFieldOptions,
@@ -93,7 +94,7 @@ function buildCreateCharacterMessage(
       const fieldKey = `game:${t.id}`;
       if (t.field_type === 'count') {
         const meta = draftData[`meta:${fieldKey}`];
-        return isRecord(meta) && meta.max != null;
+        return isRecord(meta) && formatCharacterStatValue({ field_type: 'count', meta }) !== null;
       } else {
         const value = draftData[fieldKey];
         return value && value.toString().trim();
@@ -113,9 +114,12 @@ function buildCreateCharacterMessage(
 
       if (t.field_type === 'count') {
         const meta = draftData[`meta:${fieldKey}`];
-        if (isRecord(meta) && meta.max != null) {
+        const formatted = isRecord(meta)
+          ? formatCharacterStatValue({ field_type: 'count', meta })
+          : null;
+        if (formatted) {
           filled = true;
-          display = `${meta.current ?? meta.max} / ${meta.max}`;
+          display = formatted;
         }
       } else {
         const value = draftData[fieldKey];

--- a/tests/integration/components/character_selector_stat_display.test.ts
+++ b/tests/integration/components/character_selector_stat_display.test.ts
@@ -1,0 +1,104 @@
+import type { APIStringSelectComponent } from 'discord.js';
+
+import { rebuildListCharactersResponse } from '../../../src/components/rebuild_list_characters_response';
+import { build as buildSwitchCharacterSelector } from '../../../src/components/switch_character_selector';
+import {
+  getCharactersByUser,
+  getCharacterWithStats,
+} from '../../../src/services/character.service';
+import { getCurrentCharacter, getCurrentGame } from '../../../src/services/player.service';
+import type { CharacterWithStats } from '../../../src/types/character';
+import { validateGameAccess } from '../../../src/utils/validate_game_access';
+
+jest.mock('../../../src/services/character.service', () => ({
+  getCharactersByUser: jest.fn(),
+  getCharacterWithStats: jest.fn(),
+}));
+jest.mock('../../../src/services/player.service', () => ({
+  getCurrentCharacter: jest.fn(),
+  getCurrentGame: jest.fn(),
+}));
+jest.mock('../../../src/utils/validate_game_access', () => ({
+  validateGameAccess: jest.fn(),
+}));
+
+const getCharactersByUserMock = getCharactersByUser as jest.MockedFunction<
+  typeof getCharactersByUser
+>;
+const getCharacterWithStatsMock = getCharacterWithStats as jest.MockedFunction<
+  typeof getCharacterWithStats
+>;
+const getCurrentCharacterMock = getCurrentCharacter as jest.MockedFunction<
+  typeof getCurrentCharacter
+>;
+const getCurrentGameMock = getCurrentGame as jest.MockedFunction<typeof getCurrentGame>;
+const validateGameAccessMock = validateGameAccess as jest.MockedFunction<typeof validateGameAccess>;
+
+describe('character selector stat summaries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const fullCharacter = character();
+    getCurrentGameMock.mockResolvedValue('game-1');
+    getCurrentCharacterMock.mockResolvedValue('character-1');
+    getCharactersByUserMock.mockResolvedValue([fullCharacter]);
+    getCharacterWithStatsMock.mockResolvedValue(fullCharacter);
+    validateGameAccessMock.mockResolvedValue({ valid: true });
+  });
+
+  test('formats count values in the switch-character dropdown', async () => {
+    const response = await buildSwitchCharacterSelector('user-1', 'guild-1');
+    expect('components' in response).toBe(true);
+
+    const dropdown = response.components[0].toJSON().components[0] as APIStringSelectComponent;
+    expect(dropdown.options[0].description).toContain('HP: 8 / 12');
+    expect(dropdown.options[0].description).toContain('MP: 4 / 4');
+  });
+
+  test('formats count values in the public-character dropdown', async () => {
+    const response = await rebuildListCharactersResponse(
+      [
+        {
+          id: 'character-1',
+          name: 'Mara',
+          created_at: '2026-01-01T00:00:00.000Z',
+          visibility: 'public',
+        },
+      ],
+      0,
+      'user-1',
+      'guild-1',
+    );
+
+    const dropdown = response.components[0].toJSON().components[0] as APIStringSelectComponent;
+    expect(dropdown.options[0].description).toContain('HP: 8 / 12');
+    expect(dropdown.options[0].description).toContain('MP: 4 / 4');
+  });
+});
+
+function character(): CharacterWithStats {
+  return {
+    id: 'character-1',
+    game_id: 'game-1',
+    user_id: 'user-1',
+    name: 'Mara',
+    visibility: 'public',
+    created_at: '2026-01-01T00:00:00.000Z',
+    stats: [
+      {
+        template_id: 'hp',
+        label: 'HP',
+        field_type: 'count',
+        value: '',
+        meta: { current: 8, max: 12 },
+      },
+      {
+        template_id: 'mp',
+        label: 'MP',
+        field_type: 'count',
+        value: '',
+        meta: { max: 4 },
+      },
+    ],
+    customFields: [],
+  };
+}

--- a/tests/integration/components/edit_character_stats_button.test.ts
+++ b/tests/integration/components/edit_character_stats_button.test.ts
@@ -1,0 +1,111 @@
+import type { APIStringSelectComponent, ButtonInteraction } from 'discord.js';
+
+import { handle as handleCalculateCharacterStats } from '../../../src/components/calculate_character_stats_button';
+import { handle } from '../../../src/components/edit_character_stats_button';
+import type { DiscordInteractionResponder } from '../../../src/discord/interaction_responder';
+import { getCharacterWithStats } from '../../../src/services/character.service';
+import type { CharacterWithStats } from '../../../src/types/character';
+import { isActiveCharacter } from '../../../src/utils/is_active_character';
+
+jest.mock('../../../src/services/character.service', () => ({
+  getCharacterWithStats: jest.fn(),
+}));
+jest.mock('../../../src/utils/is_active_character', () => ({
+  isActiveCharacter: jest.fn(),
+}));
+
+const getCharacterWithStatsMock = getCharacterWithStats as jest.MockedFunction<
+  typeof getCharacterWithStats
+>;
+const isActiveCharacterMock = isActiveCharacter as jest.MockedFunction<typeof isActiveCharacter>;
+
+describe('edit character stats dropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isActiveCharacterMock.mockResolvedValue(true);
+  });
+
+  test('shows count values using the shared current/max format', async () => {
+    getCharacterWithStatsMock.mockResolvedValue(character());
+    const response = responder();
+
+    await handle(interaction(), response);
+
+    const payload = (response.respond as jest.Mock).mock.calls[0][0];
+    const dropdown = payload.components[0].toJSON().components[0] as APIStringSelectComponent;
+    const descriptions = Object.fromEntries(
+      dropdown.options.map((option) => [option.label, option.description]),
+    );
+
+    expect(descriptions.HP).toBe('Current: 8 / 12');
+    expect(descriptions.MP).toBe('Current: 4 / 4');
+    expect(descriptions.Class).toBe('Current: Wizard');
+  });
+
+  test('shows the same count values in the quick-math dropdown', async () => {
+    getCharacterWithStatsMock.mockResolvedValue(character());
+    const response = responder();
+
+    await handleCalculateCharacterStats(
+      interaction('calculateCharacterStats:character-1'),
+      response,
+    );
+
+    const payload = (response.respond as jest.Mock).mock.calls[0][0];
+    const dropdown = payload.components[0].toJSON().components[0] as APIStringSelectComponent;
+    const descriptions = Object.fromEntries(
+      dropdown.options.map((option) => [option.label, option.description]),
+    );
+
+    expect(descriptions.HP).toBe('Current: 8 / 12');
+    expect(descriptions.MP).toBe('Current: 4 / 4');
+  });
+});
+
+function character(): CharacterWithStats {
+  return {
+    id: 'character-1',
+    game_id: 'game-1',
+    user_id: 'user-1',
+    name: 'Mara',
+    visibility: 'private',
+    stats: [
+      {
+        template_id: 'hp',
+        label: 'HP',
+        field_type: 'count',
+        value: '',
+        meta: { current: 8, max: 12 },
+      },
+      {
+        template_id: 'mp',
+        label: 'MP',
+        field_type: 'count',
+        value: '',
+        meta: { max: 4 },
+      },
+      {
+        template_id: 'class',
+        label: 'Class',
+        field_type: 'short',
+        value: 'Wizard',
+        meta: {},
+      },
+    ],
+    customFields: [],
+  };
+}
+
+function interaction(customId = 'editCharacterStat:character-1'): ButtonInteraction {
+  return {
+    customId,
+    user: { id: 'user-1' },
+    guildId: 'guild-1',
+  } as unknown as ButtonInteraction;
+}
+
+function responder(): DiscordInteractionResponder {
+  return {
+    respond: jest.fn().mockResolvedValue(undefined),
+  } as unknown as DiscordInteractionResponder;
+}

--- a/tests/integration/components/view_character_card.test.ts
+++ b/tests/integration/components/view_character_card.test.ts
@@ -17,6 +17,25 @@ function character(overrides: Partial<CharacterWithStats> = {}): CharacterWithSt
 }
 
 describe('view_character_card', () => {
+  test('renders count stats using the shared current/max format', () => {
+    const view = build(
+      character({
+        stats: [
+          {
+            template_id: 'hp',
+            label: 'HP',
+            field_type: 'count',
+            value: '',
+            meta: { current: 8, max: 12 },
+          },
+        ],
+      }),
+    );
+
+    const values = (view.embeds[0].data.fields ?? []).map((field) => field.value);
+    expect(values).toContain('**HP**: 8 / 12');
+  });
+
   test('renders equipped inventory items at the end of the character sheet', () => {
     const view = build(
       character({

--- a/tests/unit/utils/character_stat_display.test.ts
+++ b/tests/unit/utils/character_stat_display.test.ts
@@ -1,0 +1,28 @@
+import { formatCharacterStatValue } from '../../../src/utils/character_stat_display';
+
+describe('formatCharacterStatValue', () => {
+  test('formats count stats as current over max', () => {
+    expect(
+      formatCharacterStatValue({
+        field_type: 'count',
+        value: '',
+        meta: { current: 8, max: 12 },
+      }),
+    ).toBe('8 / 12');
+  });
+
+  test('defaults count current to max and accepts legacy numeric strings', () => {
+    expect(formatCharacterStatValue({ field_type: 'count', meta: { max: '12' } })).toBe('12 / 12');
+  });
+
+  test('returns null for count stats without a valid max', () => {
+    expect(formatCharacterStatValue({ field_type: 'count', meta: { current: 8 } })).toBeNull();
+    expect(formatCharacterStatValue({ field_type: 'count', meta: { max: 'invalid' } })).toBeNull();
+  });
+
+  test('normalizes ordinary stat values and preserves zero', () => {
+    expect(formatCharacterStatValue({ field_type: 'short', value: '  Wizard  ' })).toBe('Wizard');
+    expect(formatCharacterStatValue({ field_type: 'number', value: 0 })).toBe('0');
+    expect(formatCharacterStatValue({ field_type: 'short', value: '   ' })).toBeNull();
+  });
+});

--- a/tests/unit/utils/count_stat_defaults.test.ts
+++ b/tests/unit/utils/count_stat_defaults.test.ts
@@ -1,6 +1,7 @@
 import type { StatTemplate } from '../../../src/types/stat_template';
 import {
   applyCountStatDefaultsToDraft,
+  formatCountStatValue,
   formatStatTemplateDefault,
   getCountStatDefaults,
   parseCountDefault,
@@ -22,6 +23,12 @@ function countTemplate(overrides: Partial<StatTemplate> = {}): StatTemplate {
 }
 
 describe('count stat defaults', () => {
+  test('formats current and max from numeric or legacy string metadata', () => {
+    expect(formatCountStatValue({ current: 4, max: 10 })).toBe('4 / 10');
+    expect(formatCountStatValue({ max: '10' })).toBe('10 / 10');
+    expect(formatCountStatValue({ current: 4 })).toBeNull();
+  });
+
   test('uses max as current when no explicit current default exists', () => {
     expect(getCountStatDefaults(countTemplate())).toEqual({ max: 10, current: 10 });
     expect(formatStatTemplateDefault(countTemplate())).toBe('10 / 10');

--- a/tests/unit/utils/rebuild_create_character_response.test.ts
+++ b/tests/unit/utils/rebuild_create_character_response.test.ts
@@ -68,6 +68,7 @@ describe('rebuildCreateCharacterResponse', () => {
     expect(response.content).toContain(
       'Optional RP Proxy and USER fields remain available until set.',
     );
+    expect(response.content).toContain('- [GAME] HP 🟢 4 / 4');
     expect(response.components.at(-1)?.toJSON().components[0]).toEqual(
       expect.objectContaining({ custom_id: 'submitNewCharacter', disabled: true }),
     );


### PR DESCRIPTION
## Summary

Fixes missing values for `count` fields in character-edit dropdowns and unifies character-stat formatting across the app.

### Changes

- Added shared character-stat and count-value formatters.
- Standardized count display as `current / max`.
- Defaults missing current values to max.
- Supports legacy numeric-string metadata.
- Treats missing or invalid max values as unset.
- Migrated formatting in:

  - Character edit dropdown
  - Quick-math dropdown
  - Character card
  - Switch-character dropdown
  - Public-character dropdown
  - Character-creation summary
  - Stat-template defaults

### Testing

- Added unit coverage for count and ordinary stat formatting.
- Added integration coverage for every affected dropdown/card surface.
- Lint and build pass.
- Discord-boundary audit reports 0 findings.
- 83 test suites and 445 tests pass.